### PR TITLE
fix: no enviroment key from configmap

### DIFF
--- a/configuration.md
+++ b/configuration.md
@@ -161,7 +161,7 @@ spec:
       valueFrom:
         configMapKeyRef:
           name: envcfgmap
-          key: environment
+          key: var1
   dnsPolicy: ClusterFirst
   restartPolicy: Never
 status: {}


### PR DESCRIPTION
should be var1, as configured from previous configmap creation