### PR TITLE
Fixed nginx instead of busybox copy&paste errors

### DIFF
--- a/core-concepts.md
+++ b/core-concepts.md
@@ -274,7 +274,7 @@ kubectl exec -it busybox -- wget -o- <IP Address>
 <p>
 
 ```
-kubectl run busybox --image=nginx --restart=Never -it -- echo "How are you"
+kubectl run busybox --image=busybox --restart=Never -it -- echo "How are you"
 
 kubectl delete po busybox
 ```
@@ -287,7 +287,7 @@ kubectl delete po busybox
 
 ```
 // notice the --rm flag
-kubectl run busybox --image=nginx --restart=Never -it --rm -- echo "How are you"
+kubectl run busybox --image=busybox --restart=Never -it --rm -- echo "How are you"
 ```
 </p>
 </details>


### PR DESCRIPTION
I found out that in two exercises stating "Create a busybox pod" the commands in the solution create a nginx pod instead